### PR TITLE
Add SECURITY.md – Security Policy for Responsible Vulnerability Disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy for schulverwaltungsProgramm
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this repository, please report it responsibly by sending an email to [opensource-security@github.com](mailto:opensource-security@github.com). Avoid disclosing vulnerabilities publicly via GitHub issues or pull requests.
+
+### Please include the following information in your report:
+
+- **Type of vulnerability** (e.g., SQL Injection, Cross-Site Scripting)
+- **Affected file(s)** and **line(s)** of code
+- **Branch/commit** or **tag** where the issue occurs
+- **Steps to reproduce** the vulnerability (as detailed as possible)
+- **Example code** or **proof of concept** (if available)
+- **Potential impact** of the vulnerability (e.g., unauthorized access, data loss)
+
+## Security Guidelines
+
+- **Responsible Disclosure:** We are committed to addressing all reported security issues within 90 days and will publicly disclose the resolution after the fix is available.
+- **No Bug Bounty:** This repository is not part of a paid bug bounty program, but we highly appreciate community efforts to improve our security.
+- **Confidentiality:** Your report will be kept confidential until the issue is resolved.
+
+## Supported Versions
+
+This repository is actively maintained. Security patches will be released regularly. Please ensure you are using the latest version.
+
+## Contact
+
+If you have questions or need more information, feel free to contact us at [opensource-security@github.com](mailto:opensource-security@github.com).
+
+Thank you for helping to keep this project secure!


### PR DESCRIPTION
Dear fellow GitHub members,

This pull request introduces a `SECURITY.md` file to the root of the repository. The purpose of this file is to define clear guidelines for reporting security vulnerabilities in a responsible and confidential manner.

**Key additions:**

* Contact instructions for reporting security issues via email
* Information required for vulnerability submissions (e.g. type, location, proof of concept)
* Commitment to responsible disclosure and confidentiality
* Statement regarding supported versions and update policy

Adding this policy will help protect the project and its users by enabling the community to report potential threats properly and efficiently.

Please review and feel free to suggest improvements or additions!

Best regards,
Your Github Friend
